### PR TITLE
feat: accept database connection object as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ To develop pg-comtrade, you will need to install the package in editable mode, a
 pip install -e '.[dev]'
 ```
 
+And start a local PostgreSQL server:
+```bash
+./start-services.sh
+```
+
 And then to run the tests:
 
 ```bash

--- a/pg_comtrade.py
+++ b/pg_comtrade.py
@@ -2,9 +2,8 @@ import sqlalchemy
 from sqlalchemy.sql import text as sql_text
 import pandas as pd
 
-sql_engine = sqlalchemy.create_engine("postgresql://")
 
-def sync(schema,table,df, if_exists="fail", index=False, **kwargs):
+def sync(connection, schema, table, df, if_exists="fail", index=False, **kwargs):
     """
     ingest a single row of hard coded data into the table
 
@@ -23,20 +22,20 @@ def sync(schema,table,df, if_exists="fail", index=False, **kwargs):
     be possible to convert the cells to another format (e.g. a list-of-lists,
     or a JSON object)
     """
-    with sql_engine.connect() as connection:
-        df.to_sql(
-            table,
-            con=connection,
-            schema=schema,
-            index=index,
-            if_exists=if_exists,
-            **kwargs,
-        )
+
+    df.to_sql(
+        table,
+        con=connection,
+        schema=schema,
+        index=index,
+        if_exists=if_exists,
+        **kwargs,
+    )
     
     return schema
 
 
-def query(sql, params=None):
+def query(connection, sql, params=None):
     """
     Read full results set from Data Workspace based on arbitrary query
 
@@ -49,5 +48,4 @@ def query(sql, params=None):
         df: pandas dataframe read from Data Workspace
     """
 
-    with sql_engine.connect() as connection:
-        return pd.read_sql(sql_text(sql), connection, params=params)
+    return pd.read_sql(sql_text(sql), connection, params=params)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+  "sqlalchemy>=1.4.24",
+]
 
 [project.urls]
 "Source" = "https://github.com/uktrade/pg-comtrade"
@@ -23,6 +26,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
   "pytest>=7.4.4",
+  "psycopg2-binary",
 ]
 
 [tool.hatch.build]

--- a/start-services.sh
+++ b/start-services.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+docker run --rm -it --name pg-comtrade-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d ${1:-postgres}

--- a/stop-services.sh
+++ b/stop-services.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+docker stop pg-comtrade-postgres


### PR DESCRIPTION
This changes the code to accept a database connection object as an argument. This is to allow client code to customise it (say for engine type, hostname, password etc.)